### PR TITLE
Fix #8: Add isEmpty Helper

### DIFF
--- a/src/runner/helpers/array.ts
+++ b/src/runner/helpers/array.ts
@@ -161,8 +161,16 @@ function unique(arr: any): any[] {
     return Array.from(new Set(arr));
 }
 
+function isEmpty(arr: any): boolean {
+    if(!Array.isArray(arr)) {
+        return false;
+    }
+
+    return arr.length === 0;
+}
+
 export const arrayHelpers = Object.assign(Object.create(null), {
     first, last, itemAt, length, after, before, slice, includes,
     contains: includes, isArray, each, forEach, join, merge,
-    reverse, pluck, unique,
+    reverse, pluck, unique, isEmpty
 });

--- a/test/array-helpers.spec.js
+++ b/test/array-helpers.spec.js
@@ -351,4 +351,14 @@ describe('helpers', () => { describe('array', () => {
         });
     });
 
+    describe('isEmpty', () => {
+      it('should return true if and only if its an array and the array is empty', async () => {
+        const templ = compile(`{{isEmpty arr}}`);
+        expect(await templ({ arr: [] })).to.equal('true');
+        expect(await templ({ arr: [1] })).to.equal('false');
+        expect(await templ({ arr: [1, 2, 3] })).to.equal('false');
+        expect(await templ({ arr: 'foo' })).to.equal('false');
+      });
+    })
+
 }); });


### PR DESCRIPTION
This PR fixes #8 : adds the `isEmpty` in the `array` helper file and the tests in the `array-helpers-spec` file.



![Screenshot from 2021-10-04 12-40-59](https://user-images.githubusercontent.com/70739349/135809031-f35d7899-8143-4fba-9cb6-57760f4055fc.png)

